### PR TITLE
Don't write FUNCTION_URI as a profile.d entry

### DIFF
--- a/node/riff_invoker.go
+++ b/node/riff_invoker.go
@@ -90,10 +90,7 @@ func (r RiffNodeInvoker) Contribute() error {
 	}
 
 	entrypoint := filepath.Join(r.application.Root, r.functionJS)
-	if e := r.layer.WriteProfile("function-uri", `export FUNCTION_URI="%s"`, entrypoint) ; e != nil {
-		return e
-	}
-	command := fmt.Sprintf(`node %s/server.js`, r.layer.Root)
+	command := fmt.Sprintf(`FUNCTION_URI="%s" node %s/server.js`, entrypoint, r.layer.Root)
 
 	return r.launch.WriteMetadata(libbuildpack.LaunchMetadata{
 		Processes: libbuildpack.Processes{


### PR DESCRIPTION
Previously, the FUNCTON_URI var was set via a `profile.d` entry.
This had the side effect of creating the directory for the layer,
thus bypassing the export-from-cached-layer phase for that particular
layer (even though the buildpack thought it would use caching).

Fixes #30